### PR TITLE
Update type_packing_tests.cpp

### DIFF
--- a/msgpack/tests/type_packing_tests.cpp
+++ b/msgpack/tests/type_packing_tests.cpp
@@ -2,7 +2,7 @@
 // Created by Mike Loomis on 6/22/2019.
 //
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <msgpack/msgpack.hpp>
 


### PR DESCRIPTION
https://github.com/catchorg/Catch2/blob/devel/docs/migrate-v2-to-v3.md#top

V2 & V3 migration requires cmakelists be updated and the include changed accordingly: Try

#include <catch2/catch_test_macros.hpp>

or

#include <catch2/catch_all.hpp>